### PR TITLE
Add ArgoCD sync waves to manifests and Ansible setup

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,240 @@
+# K3s Ansible Setup
+
+This directory contains Ansible playbooks to set up a K3s cluster with a control plane and worker nodes.
+
+## Prerequisites
+
+1. **Ansible installed** on your local machine:
+   ```bash
+   sudo apt update
+   sudo apt install ansible
+   ```
+
+2. **SSH access** configured to both nodes:
+   - Control plane: `192.168.178.81`
+   - Worker: `192.168.178.82`
+
+3. **SSH keys** set up for passwordless authentication:
+   ```bash
+   ssh-copy-id ubuntu@192.168.178.81
+   ssh-copy-id ubuntu@192.168.178.82
+   ```
+
+4. **Sudo privileges** without password on both nodes (if needed):
+   ```bash
+   # On each node, add to /etc/sudoers.d/ubuntu
+   ubuntu ALL=(ALL) NOPASSWD:ALL
+   ```
+
+## Configuration
+
+### Inventory File
+
+The `inventory.ini` file defines the cluster nodes:
+
+```ini
+[k3s_control_plane]
+controlplane ansible_host=192.168.178.81 ansible_user=ubuntu
+
+[k3s_workers]
+worker-1 ansible_host=192.168.178.82 ansible_user=ubuntu
+```
+
+**Customize:**
+- Update `ansible_user` if you use a different username
+- Adjust IP addresses if they change
+- Add more workers by adding entries under `[k3s_workers]`
+
+## Usage
+
+### Setup K3s Cluster
+
+Run the main playbook to install and configure the K3s cluster:
+
+```bash
+cd ansible
+ansible-playbook k3s-setup.yml
+```
+
+This playbook will:
+1. Install K3s on the control plane node
+2. Retrieve the node token from the control plane
+3. Install K3s agent on worker nodes and join them to the cluster
+4. Verify the cluster is running
+
+### Reset/Remove K3s Cluster
+
+To completely remove K3s from all nodes:
+
+```bash
+ansible-playbook k3s-reset.yml
+```
+
+This will uninstall K3s from all nodes and clean up directories.
+
+### Access the Cluster
+
+After successful installation, you can access the cluster from the control plane:
+
+```bash
+ssh ubuntu@192.168.178.81
+kubectl get nodes
+kubectl get pods -A
+```
+
+Or copy the kubeconfig to your local machine:
+
+```bash
+scp ubuntu@192.168.178.81:/etc/rancher/k3s/k3s.yaml ~/.kube/k3s-config
+# Edit the file and change server: https://127.0.0.1:6443 to server: https://192.168.178.81:6443
+export KUBECONFIG=~/.kube/k3s-config
+kubectl get nodes
+```
+
+## Playbook Details
+
+### k3s-setup.yml
+
+- **Control Plane Setup:**
+  - Installs K3s server with Traefik ingress controller enabled
+  - Sets kubeconfig permissions to `644` for easy access
+  - Retrieves the node token for workers to join
+
+- **Worker Setup:**
+  - Installs K3s agent
+  - Automatically joins the control plane using the token
+  - Verifies the agent is running
+
+- **Verification:**
+  - Waits for all nodes to be ready
+  - Displays cluster status and running pods
+
+### k3s-reset.yml
+
+- Uninstalls K3s from all nodes
+- Removes configuration directories
+- Cleans up iptables rules on the control plane
+
+### argocd-setup.yml
+
+Installs and configures ArgoCD for GitOps-based deployments using existing manifests from `../manifests/apps/argo-cd/`.
+
+**To install ArgoCD:**
+
+```bash
+cd ansible
+ansible-playbook argocd-setup.yml
+```
+
+This playbook will:
+1. Apply the ArgoCD namespace from `../manifests/apps/argo-cd/namespace.yaml`
+2. Install ArgoCD using the official manifests
+3. Wait for ArgoCD server to be ready
+4. Apply the ArgoCD ingress from `../manifests/apps/argo-cd/ingress.yaml`
+5. Retrieve and display the initial admin password
+
+**Access ArgoCD UI:**
+
+After installation:
+
+1. Add to your `/etc/hosts`:
+   ```bash
+   echo "192.168.178.81 argocd.local" | sudo tee -a /etc/hosts
+   ```
+
+2. Access the UI at: `http://argocd.local`
+
+3. Login with:
+   - Username: `admin`
+   - Password: (displayed at the end of the playbook or retrieve with):
+     ```bash
+     kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+     ```
+
+**Alternative: Port-forward (temporary access):**
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+Then access at: `https://localhost:8080`
+
+## Troubleshooting
+
+### Connection Issues
+
+Test connectivity:
+```bash
+ansible all -m ping
+```
+
+### SSH Key Issues
+
+Ensure your SSH key is added:
+```bash
+ssh-add ~/.ssh/id_rsa
+```
+
+### Check K3s Status
+
+On control plane:
+```bash
+ssh ubuntu@192.168.178.81
+sudo systemctl status k3s
+```
+
+On worker:
+```bash
+ssh ubuntu@192.168.178.82
+sudo systemctl status k3s-agent
+```
+
+### View Logs
+
+Control plane:
+```bash
+sudo journalctl -u k3s -f
+```
+
+Worker:
+```bash
+sudo journalctl -u k3s-agent -f
+```
+
+## Customization
+
+### Traefik Ingress Controller
+
+The playbook enables Traefik by default, providing an ingress controller out of the box. To disable it, add `--disable=traefik` to the install command in `k3s-setup.yml`:
+
+```yaml
+curl -sfL https://get.k3s.io | sh -s - server \
+  --write-kubeconfig-mode=644 \
+  --disable=traefik
+```
+
+### Additional K3s Options
+
+You can add more K3s server options by modifying the install command:
+
+```yaml
+curl -sfL https://get.k3s.io | sh -s - server \
+  --write-kubeconfig-mode=644 \
+  --flannel-backend=vxlan \
+  --cluster-cidr=10.42.0.0/16
+```
+
+See [K3s documentation](https://docs.k3s.io/installation/configuration) for all options.
+
+## Next Steps
+
+After the cluster is set up:
+1. **Install ArgoCD** for GitOps deployments:
+   ```bash
+   ansible-playbook argocd-setup.yml
+   ```
+   (The playbook automatically applies namespace and ingress from `../manifests/apps/argo-cd/`)
+2. **Access Traefik dashboard** at `http://traefik.local/dashboard/` (add to `/etc/hosts` first)
+3. **Deploy your applications** using kubectl or ArgoCD from the `../manifests` directory
+4. Configure additional Ingress resources to expose your applications
+5. Add persistent storage if needed for stateful applications

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,16 @@
+[defaults]
+inventory = inventory.ini
+host_key_checking = False
+retry_files_enabled = False
+stdout_callback = yaml
+interpreter_python = auto_silent
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/ansible/argocd-setup.yml
+++ b/ansible/argocd-setup.yml
@@ -1,0 +1,63 @@
+---
+- name: Install and Configure ArgoCD
+  hosts: k3s_control_plane
+  become: yes
+  vars:
+    manifests_dir: "/home/marco/Development/learning-k3s/manifests/apps/argo-cd"
+  tasks:
+    - name: Apply ArgoCD namespace from existing manifests
+      command: kubectl apply -f {{ manifests_dir }}/namespace.yaml
+      register: argocd_namespace
+      changed_when: "'created' in argocd_namespace.stdout or 'configured' in argocd_namespace.stdout"
+
+    - name: Install ArgoCD
+      command: >
+        kubectl apply -n argocd -f
+        https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+      register: argocd_install
+      changed_when: "'created' in argocd_install.stdout or 'configured' in argocd_install.stdout"
+
+    - name: Wait for ArgoCD server to be ready
+      command: kubectl wait --for=condition=available --timeout=300s deployment/argocd-server -n argocd
+      register: argocd_ready
+      changed_when: false
+      retries: 3
+      delay: 10
+      until: argocd_ready.rc == 0
+
+    - name: Apply ArgoCD ingress from existing manifests
+      command: kubectl apply -f {{ manifests_dir }}/ingress.yaml
+      register: argocd_ingress
+      changed_when: "'created' in argocd_ingress.stdout or 'configured' in argocd_ingress.stdout"
+
+    - name: Get ArgoCD admin password
+      shell: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+      register: argocd_password
+      changed_when: false
+      failed_when: false
+
+    - name: Display ArgoCD access information
+      debug:
+        msg:
+          - "ArgoCD has been installed successfully!"
+          - "Username: admin"
+          - "Password: {{ argocd_password.stdout }}"
+          - ""
+          - "ArgoCD ingress has been configured from: manifests/apps/argo-cd/ingress.yaml"
+          - ""
+          - "To access ArgoCD:"
+          - "1. Add '192.168.178.81 argocd.local' to your /etc/hosts file"
+          - "2. Access the UI at: http://argocd.local"
+          - ""
+          - "Or use port-forward temporarily:"
+          - "kubectl port-forward svc/argocd-server -n argocd 8080:443"
+      when: argocd_password.stdout != ""
+
+    - name: Get ArgoCD server status
+      command: kubectl get pods -n argocd
+      register: argocd_pods
+      changed_when: false
+
+    - name: Display ArgoCD pods
+      debug:
+        var: argocd_pods.stdout_lines

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,13 @@
+[k3s_cluster:children]
+k3s_control_plane
+k3s_workers
+
+[k3s_control_plane]
+controlplane ansible_host=192.168.178.81 ansible_user=marco
+
+[k3s_workers]
+worker-1 ansible_host=192.168.178.82 ansible_user=marco
+
+[k3s_cluster:vars]
+ansible_python_interpreter=/usr/bin/python3
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/ansible/k3s-reset.yml
+++ b/ansible/k3s-reset.yml
@@ -1,0 +1,66 @@
+---
+- name: Reset K3s Worker Nodes
+  hosts: k3s_workers
+  become: yes
+  tasks:
+    - name: Check if K3s agent uninstall script exists
+      stat:
+        path: /usr/local/bin/k3s-agent-uninstall.sh
+      register: k3s_agent_uninstall
+
+    - name: Uninstall K3s agent
+      command: /usr/local/bin/k3s-agent-uninstall.sh
+      when: k3s_agent_uninstall.stat.exists
+      ignore_errors: yes
+
+    - name: Remove K3s directories on workers
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /var/lib/rancher
+        - /etc/rancher
+
+- name: Reset K3s Control Plane
+  hosts: k3s_control_plane
+  become: yes
+  tasks:
+    - name: Check if K3s uninstall script exists
+      stat:
+        path: /usr/local/bin/k3s-uninstall.sh
+      register: k3s_uninstall
+
+    - name: Uninstall K3s server
+      command: /usr/local/bin/k3s-uninstall.sh
+      when: k3s_uninstall.stat.exists
+      ignore_errors: yes
+
+    - name: Remove K3s directories on control plane
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /var/lib/rancher
+        - /etc/rancher
+
+    - name: Clean iptables rules
+      command: "{{ item }}"
+      loop:
+        - iptables -F
+        - iptables -t nat -F
+        - iptables -t mangle -F
+        - iptables -X
+      ignore_errors: yes
+
+- name: Verify K3s Removal
+  hosts: k3s_cluster
+  become: yes
+  tasks:
+    - name: Check if K3s binary still exists
+      stat:
+        path: /usr/local/bin/k3s
+      register: k3s_binary
+
+    - name: Display removal status
+      debug:
+        msg: "K3s has been {{ 'NOT ' if k3s_binary.stat.exists else '' }}removed successfully"

--- a/ansible/k3s-setup.yml
+++ b/ansible/k3s-setup.yml
@@ -1,0 +1,122 @@
+---
+- name: Setup K3s Control Plane
+  hosts: k3s_control_plane
+  become: yes
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Install required packages
+      apt:
+        name:
+          - curl
+          - apt-transport-https
+          - ca-certificates
+        state: present
+
+    - name: Check if K3s is already installed
+      stat:
+        path: /usr/local/bin/k3s
+      register: k3s_installed
+
+    - name: Install K3s server
+      shell: |
+        curl -sfL https://get.k3s.io | sh -s - server \
+          --write-kubeconfig-mode=644
+      when: not k3s_installed.stat.exists
+
+    - name: Wait for K3s to be ready
+      wait_for:
+        path: /var/lib/rancher/k3s/server/node-token
+        state: present
+        timeout: 300
+
+    - name: Get K3s node token
+      slurp:
+        src: /var/lib/rancher/k3s/server/node-token
+      register: k3s_token
+
+    - name: Save token for workers
+      set_fact:
+        k3s_node_token: "{{ k3s_token.content | b64decode | trim }}"
+
+    - name: Get K3s server status
+      command: systemctl status k3s
+      register: k3s_status
+      changed_when: false
+      failed_when: false
+
+    - name: Display K3s server status
+      debug:
+        var: k3s_status.stdout_lines
+
+- name: Setup K3s Worker Nodes
+  hosts: k3s_workers
+  become: yes
+  vars:
+    k3s_url: "https://{{ hostvars[groups['k3s_control_plane'][0]]['ansible_host'] }}:6443"
+    k3s_token: "{{ hostvars[groups['k3s_control_plane'][0]]['k3s_node_token'] }}"
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Install required packages
+      apt:
+        name:
+          - curl
+          - apt-transport-https
+          - ca-certificates
+        state: present
+
+    - name: Check if K3s agent is already installed
+      stat:
+        path: /usr/local/bin/k3s
+      register: k3s_agent_installed
+
+    - name: Install K3s agent
+      shell: |
+        curl -sfL https://get.k3s.io | K3S_URL="{{ k3s_url }}" K3S_TOKEN="{{ k3s_token }}" sh -
+      when: not k3s_agent_installed.stat.exists
+
+    - name: Wait for K3s agent to be ready
+      wait_for:
+        timeout: 30
+
+    - name: Get K3s agent status
+      command: systemctl status k3s-agent
+      register: k3s_agent_status
+      changed_when: false
+      failed_when: false
+
+    - name: Display K3s agent status
+      debug:
+        var: k3s_agent_status.stdout_lines
+
+- name: Verify K3s Cluster
+  hosts: k3s_control_plane
+  become: yes
+  tasks:
+    - name: Wait for nodes to be ready
+      shell: kubectl get nodes
+      register: nodes_status
+      until: nodes_status.stdout.find("NotReady") == -1
+      retries: 10
+      delay: 10
+      changed_when: false
+
+    - name: Display cluster nodes
+      debug:
+        var: nodes_status.stdout_lines
+
+    - name: Get all pods
+      command: kubectl get pods -A
+      register: all_pods
+      changed_when: false
+
+    - name: Display all pods
+      debug:
+        var: all_pods.stdout_lines

--- a/manifests/apps/argo-cd/ingress.yaml
+++ b/manifests/apps/argo-cd/ingress.yaml
@@ -4,6 +4,8 @@ kind: ServersTransport
 metadata:
   name: argocd-transport
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   serverName: argocd-server
   insecureSkipVerify: true
@@ -13,6 +15,8 @@ kind: IngressRoute
 metadata:
   name: argocd-server
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   entryPoints:
     - websecure

--- a/manifests/apps/argo-cd/namespace.yaml
+++ b/manifests/apps/argo-cd/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/manifests/apps/flame-dashboard/deployment.yaml
+++ b/manifests/apps/flame-dashboard/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: flame-dashboard-deployment
   namespace: flame-dashboard
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 2
   selector:

--- a/manifests/apps/flame-dashboard/ingress.yaml
+++ b/manifests/apps/flame-dashboard/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: flame-dashboard-ingress
   namespace: flame-dashboard
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   rules:
     - host: flame-dashboard.local

--- a/manifests/apps/flame-dashboard/namespace.yaml
+++ b/manifests/apps/flame-dashboard/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: flame-dashboard
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/manifests/apps/flame-dashboard/service.yaml
+++ b/manifests/apps/flame-dashboard/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: flame-dashboard-service
   namespace: flame-dashboard
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   selector:
     app: flame-dashboard

--- a/manifests/apps/image-processor/deployment.yaml
+++ b/manifests/apps/image-processor/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: image-processor
   namespace: image-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 2
   selector:

--- a/manifests/apps/image-processor/ingress.yaml
+++ b/manifests/apps/image-processor/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: image-processor-ingress
   namespace: image-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   rules:
     - host: image-processor.local

--- a/manifests/apps/image-processor/namespace.yaml
+++ b/manifests/apps/image-processor/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: image-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/manifests/apps/image-processor/service.yaml
+++ b/manifests/apps/image-processor/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: image-processor-service
   namespace: image-processor
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   selector:
     app: image-processor

--- a/manifests/apps/kube-prometheus-stack/ingress.yaml
+++ b/manifests/apps/kube-prometheus-stack/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: grafana-ingress
   namespace: grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   rules:
   - host: grafana.local

--- a/manifests/apps/kube-prometheus-stack/namespace.yaml
+++ b/manifests/apps/kube-prometheus-stack/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/manifests/traefik-dashboard.yaml
+++ b/manifests/traefik-dashboard.yaml
@@ -3,6 +3,8 @@ kind: IngressRoute
 metadata:
   name: traefik-dashboard
   namespace: kube-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   entryPoints:
     - web


### PR DESCRIPTION
- Add sync-wave annotations to all manifest files for proper ordering:
  - Wave 1: Namespaces (argocd, flame-dashboard, image-processor, grafana)
  - Wave 3: Deployments (flame-dashboard, image-processor)
  - Wave 4: Services (flame-dashboard, image-processor)
  - Wave 5: Ingress/IngressRoutes (all apps and traefik-dashboard)

- Add Ansible automation for K3s cluster setup:
  - k3s-setup.yml: Install K3s control plane and worker nodes
  - argocd-setup.yml: Install and configure ArgoCD
  - k3s-reset.yml: Reset/remove K3s cluster
  - inventory.ini: Define cluster nodes
  - ansible.cfg: Ansible configuration

- Update ArgoCD ingress to use Traefik IngressRoute with HTTPS
- Add comprehensive documentation in ansible/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)