### PR TITLE
Fix Grafana ingress namespace

### DIFF
--- a/manifests/apps/kube-prometheus-stack/ingress.yaml
+++ b/manifests/apps/kube-prometheus-stack/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: grafana-ingress
-  namespace: grafana
+  namespace: default
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:

--- a/manifests/apps/kube-prometheus-stack/namespace.yaml
+++ b/manifests/apps/kube-prometheus-stack/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: grafana
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"


### PR DESCRIPTION
- Move grafana-ingress from grafana namespace to default namespace
- Remove unused grafana namespace manifest
- Grafana service is deployed in default namespace by kube-prometheus-stack
- Fixes 404 error when accessing http://grafana.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)