### PR TITLE
Fix: Add namespace field to Camel K operator resources

### DIFF
--- a/manifests/apps/camel-k/operator.yaml
+++ b/manifests/apps/camel-k/operator.yaml
@@ -10,11 +10,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
   name: camel-k-operator
+  namespace: camel-k
   labels:
     app: "camel-k"
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 ---
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
@@ -24,11 +25,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
   name: camel-k-builder
+  namespace: camel-k
   labels:
     app: "camel-k"
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 ---
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
@@ -38,9 +40,8 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
   name: camel-k-operator
+  namespace: camel-k
   labels:
     app: "camel-k"
     camel.apache.org/component: operator
@@ -48,6 +49,8 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: camel-k
     app.kubernetes.io/version: "2.8.0"
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 1
   strategy:
@@ -124,11 +127,12 @@ spec:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
   name: camel-k-builder
+  namespace: camel-k
   labels:
     app: "camel-k"
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 rules:
 - apiGroups:
   - camel.apache.org
@@ -173,11 +177,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
   name: camel-k-builder
+  namespace: camel-k
   labels:
     app: "camel-k"
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 subjects:
 - kind: ServiceAccount
   name: camel-k-builder


### PR DESCRIPTION
Adds missing 'namespace: camel-k' field to all namespace-scoped resources:
- ServiceAccount: camel-k-operator
- ServiceAccount: camel-k-builder
- Deployment: camel-k-operator
- Role: camel-k-builder
- RoleBinding: camel-k-builder

This fixes ArgoCD InvalidSpecError for resources missing namespace declaration. ClusterRole and ClusterRoleBinding resources correctly remain cluster-scoped.