### PR TITLE
Fix: Add ServerSideApply to CRDs to prevent annotation size limit

### DIFF
--- a/manifests/apps/camel-k/crds.yaml
+++ b/manifests/apps/camel-k/crds.yaml
@@ -18,6 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -2159,12 +2160,12 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -2689,12 +2690,12 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -3264,12 +3265,12 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -7809,12 +7810,12 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -12098,12 +12099,12 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -22789,12 +22790,12 @@ spec:
         labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -24089,12 +24090,12 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}
----
+      status: {}---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     argocd.argoproj.io/sync-wave: "2"
     controller-gen.kubebuilder.io/version: v0.17.2
   labels:
@@ -33107,3 +33108,4 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+


### PR DESCRIPTION
Adds 'argocd.argoproj.io/sync-options: ServerSideApply=true' annotation to all 8 Camel K CRDs.

This fixes the error:
"CustomResourceDefinition.apiextensions.k8s.io is invalid: metadata.annotations: Too long: may not be more than 262144 bytes"

Server-side apply prevents ArgoCD from storing the entire CRD spec in the kubectl.kubernetes.io/last-applied-configuration annotation, which was exceeding the 262KB limit for large CRDs like integrations and pipes.

Affected CRDs:
- builds.camel.apache.org
- camelcatalogs.camel.apache.org
- integrationkits.camel.apache.org
- integrationplatforms.camel.apache.org
- integrationprofiles.camel.apache.org
- integrations.camel.apache.org (was failing)
- kamelets.camel.apache.org
- pipes.camel.apache.org (was failing)