### PR TITLE
Fix: Correct YAML document separator formatting in crds.yaml

### DIFF
--- a/manifests/apps/camel-k/crds.yaml
+++ b/manifests/apps/camel-k/crds.yaml
@@ -2160,7 +2160,8 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2690,7 +2691,8 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3265,7 +3267,8 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7810,7 +7813,8 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -12099,7 +12103,8 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -22790,7 +22795,8 @@ spec:
         labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -24090,7 +24096,8 @@ spec:
     served: true
     storage: true
     subresources:
-      status: {}---
+      status: {}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Fixes malformed YAML document separators where '---' was concatenated to the end of lines (e.g., 'status: {}---' instead of proper separation).

This resolves the ArgoCD manifest generation error: "Failed to unmarshal manifest: error converting YAML to JSON: yaml: line 2162: did not find expected key"

Changes:
- Fixed 7 occurrences of '{}---' to properly separate onto individual lines
- All 8 CRDs now have correct YAML document separators
- Validated YAML syntax using Python's yaml parser

The file now correctly parses as 8 valid YAML documents.