### PR TITLE
Add Prometheus instrumentation for component operations

### DIFF
--- a/apps/inventory/METRICS.md
+++ b/apps/inventory/METRICS.md
@@ -1,0 +1,96 @@
+# Prometheus Metrics Documentation
+
+This application exposes Prometheus metrics for monitoring component operations in the inventory system.
+
+## Metrics Endpoint
+
+The metrics are available at:
+```
+http://localhost:8000/metrics/
+```
+
+## Available Metrics
+
+### Component Metrics
+
+1. **inventory_components_created_total** (Counter)
+   - Description: Total number of components created since the application started
+   - Type: Counter
+   - Increments: When a new component is added via Django admin or API
+
+2. **inventory_components_deleted_total** (Counter)
+   - Description: Total number of components deleted since the application started
+   - Type: Counter
+   - Increments: When a component is deleted via Django admin or API
+
+3. **inventory_components_total** (Gauge)
+   - Description: Current total number of components in the inventory
+   - Type: Gauge
+   - Updates: Real-time count of all components in the database
+
+## How It Works
+
+The instrumentation is implemented using Django signals:
+
+- **Signal Handlers** (components/metrics.py:28):
+  - `component_created_handler`: Triggered on component creation
+  - `component_deleted_handler`: Triggered on component deletion
+
+- **Metrics Registration** (components/apps.py:8):
+  - Signals are registered in the `ComponentsConfig.ready()` method
+  - This ensures metrics are tracked from application startup
+
+## Testing Metrics
+
+### Via Django Admin
+
+1. Access the admin interface: http://localhost:8000/admin/
+2. Add a new component
+3. Check the metrics endpoint - `inventory_components_created_total` should increment
+4. Delete a component
+5. Check the metrics endpoint - `inventory_components_deleted_total` should increment
+
+### Via Prometheus Scraping
+
+Configure Prometheus to scrape this endpoint:
+
+```yaml
+scrape_configs:
+  - job_name: 'inventory'
+    static_configs:
+      - targets: ['inventory-service:8000']
+    metrics_path: '/metrics/'
+    scrape_interval: 15s
+```
+
+## Metrics Format
+
+The metrics are exposed in Prometheus text format:
+
+```
+# HELP inventory_components_created_total Total number of components created
+# TYPE inventory_components_created_total counter
+inventory_components_created_total 42.0
+
+# HELP inventory_components_deleted_total Total number of components deleted
+# TYPE inventory_components_deleted_total counter
+inventory_components_deleted_total 5.0
+
+# HELP inventory_components_total Current total number of components in inventory
+# TYPE inventory_components_total gauge
+inventory_components_total 37.0
+```
+
+## Production Considerations
+
+1. **Performance**: The gauge is updated on each metrics request and when components are created/deleted
+2. **Persistence**: Counters reset when the application restarts (this is standard Prometheus behavior)
+3. **Multiprocess Mode**: For production with multiple workers, consider using prometheus_client's multiprocess mode
+4. **Security**: Consider adding authentication to the /metrics endpoint in production
+
+## Related Files
+
+- `components/metrics.py` - Prometheus metrics definitions and signal handlers
+- `components/apps.py` - Signal registration
+- `components/views.py` - Metrics endpoint view
+- `inventory/urls.py` - Metrics URL routing

--- a/apps/inventory/components/apps.py
+++ b/apps/inventory/components/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class ComponentsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'components'
+
+    def ready(self):
+        """Import signal handlers when Django starts."""
+        import components.metrics  # noqa: F401

--- a/apps/inventory/components/metrics.py
+++ b/apps/inventory/components/metrics.py
@@ -1,0 +1,49 @@
+"""
+Prometheus metrics for component operations.
+"""
+from prometheus_client import Counter, Gauge
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from .models import Component
+
+# Prometheus metrics
+components_created_total = Counter(
+    'inventory_components_created_total',
+    'Total number of components created'
+)
+
+components_deleted_total = Counter(
+    'inventory_components_deleted_total',
+    'Total number of components deleted'
+)
+
+components_total = Gauge(
+    'inventory_components_total',
+    'Current total number of components in inventory'
+)
+
+
+def update_component_gauge():
+    """Update the gauge with the current component count."""
+    components_total.set(Component.objects.count())
+
+
+@receiver(post_save, sender=Component)
+def component_created_handler(sender, instance, created, **kwargs):
+    """
+    Signal handler for component creation.
+    Increments Prometheus counter when a new component is added.
+    """
+    if created:
+        components_created_total.inc()
+        update_component_gauge()
+
+
+@receiver(post_delete, sender=Component)
+def component_deleted_handler(sender, instance, **kwargs):
+    """
+    Signal handler for component deletion.
+    Increments Prometheus counter when a component is deleted.
+    """
+    components_deleted_total.inc()
+    update_component_gauge()

--- a/apps/inventory/components/views.py
+++ b/apps/inventory/components/views.py
@@ -1,5 +1,8 @@
 from django.shortcuts import render, get_object_or_404
+from django.http import HttpResponse
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from .models import Component
+from .metrics import update_component_gauge
 
 
 def component_list(request):
@@ -18,3 +21,15 @@ def component_detail(request, component_id):
         'component': component
     }
     return render(request, 'components/component_detail.html', context)
+
+
+def metrics(request):
+    """
+    Expose Prometheus metrics endpoint.
+    Returns metrics in Prometheus text format.
+    """
+    # Ensure the gauge is up-to-date before generating metrics
+    update_component_gauge()
+
+    metrics_data = generate_latest()
+    return HttpResponse(metrics_data, content_type=CONTENT_TYPE_LATEST)

--- a/apps/inventory/inventory/urls.py
+++ b/apps/inventory/inventory/urls.py
@@ -17,9 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.views.generic import RedirectView
+from components.views import metrics
 
 urlpatterns = [
     path('', RedirectView.as_view(pattern_name='component_list', permanent=False)),
     path('admin/', admin.site.urls),
+    path('metrics/', metrics, name='metrics'),
     path("components/", include("components.urls"))
 ]

--- a/apps/inventory/requirements.txt
+++ b/apps/inventory/requirements.txt
@@ -2,3 +2,4 @@ Django==5.2.6
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
 whitenoise==6.8.2
+prometheus-client==0.21.0


### PR DESCRIPTION
- Added prometheus-client dependency to track component metrics
- Implemented Prometheus counters for components created and deleted
- Implemented Prometheus gauge for current total component count
- Created signal handlers to automatically update metrics on component changes
- Exposed /metrics endpoint for Prometheus scraping
- Added comprehensive metrics documentation

Metrics available:
- inventory_components_created_total: Counter for components created
- inventory_components_deleted_total: Counter for components deleted
- inventory_components_total: Gauge for current component count